### PR TITLE
Fixed case issues after running prisma migration

### DIFF
--- a/__tests__/event.test.js
+++ b/__tests__/event.test.js
@@ -8,8 +8,8 @@ const testEvent = {
   name: "event",
   location: "here",
   description: "will be fun",
-  starttime: new Date('2022-04-17T12:00:00Z'),
-  endtime: new Date('2022-04-17T13:00:00Z')
+  startTime: new Date('2022-04-17T12:00:00Z'),
+  endTime: new Date('2022-04-17T13:00:00Z')
 }
 
 var insertedID;

--- a/__tests__/user.test.js
+++ b/__tests__/user.test.js
@@ -5,11 +5,11 @@ import handlerAdd from '../pages/api/user/add';
 jest.setTimeout(300000);
 
 const testUser = {
-  firstname: "John",
-  lastname: "Doe",
+  firstName: "John",
+  lastName: "Doe",
   email: "jdoe@rpi.edu",
-  rcsid: "jdoe",
-  joinedat: new Date('2022-04-17T09:00:00Z')
+  rcsID: "jdoe",
+  joinedAt: new Date('2022-04-17T09:00:00Z')
 }
 
 var insertedID;

--- a/pages/api/event/add.js
+++ b/pages/api/event/add.js
@@ -11,8 +11,8 @@ export default async function handler(req, res) {
         name: req.body.name,
         description: req.body.description,
         location: req.body.location,
-        starttime: req.body.starttime,
-        endtime: req.body.endtime
+        startTime: req.body.startTime,
+        endTime: req.body.endTime
       },
     })
 

--- a/pages/api/user/add.js
+++ b/pages/api/user/add.js
@@ -8,11 +8,11 @@ export default async function handler(req, res) {
     const user = await prisma.user.create({
       data: {
         id: req.body.id,
-        firstname: req.body.firstname,
-        lastname: req.body.lastname,
+        firstName: req.body.firstName,
+        lastName: req.body.lastName,
         email: req.body.email,
-        rcsid: req.body.rcsid,
-        joinedat: req.body.joinedat
+        rcsID: req.body.rcsID,
+        joinedAt: req.body.joinedAt
       },
     })
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,13 +10,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model event {
+model Event {
   id          Int      @id @default(autoincrement())
   name        String
   description String?
   location    String?
-  starttime   DateTime @default(now())
-  endtime     DateTime @default(now())
+  startTime   DateTime @default(now())
+  endTime     DateTime @default(now())
 }
 
 model Organization {


### PR DESCRIPTION
After running Prisma migrate so that our database matched the Prisma schema, some of the tests were failing due to differences in variable names. I fixed these so all the tests pass again.

Closes #17 